### PR TITLE
Don't do partial matches (e.g. pt-PT -> pt-BR)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -99,7 +99,7 @@
     };
 
     Locales.prototype.best = function(locales) {
-      var index, item, l, languageIndex, locale, normalizedIndex, setLocale, _i, _j, _len, _len1;
+      var index, item, languageIndex, locale, normalizedIndex, setLocale, _i, _len;
       setLocale = function(l) {
         var r;
         r = l;
@@ -124,13 +124,6 @@
           return setLocale(locales[normalizedIndex]);
         } else if (languageIndex != null) {
           return setLocale(locales[languageIndex]);
-        } else {
-          for (_j = 0, _len1 = locales.length; _j < _len1; _j++) {
-            l = locales[_j];
-            if (l.language === item.language) {
-              return setLocale(l);
-            }
-          }
         }
       }
       return locale;

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -86,9 +86,6 @@ class app.Locales
 
       if normalizedIndex? then return setLocale(locales[normalizedIndex])
       else if languageIndex? then return setLocale(locales[languageIndex])
-      else
-        for l in locales
-          if l.language == item.language then return setLocale(l)
 
     locale
 

--- a/src/test.coffee
+++ b/src/test.coffee
@@ -74,19 +74,19 @@ describe "Priority", ->
 
       callback()
 
-  it "should use a country specific language when an unsupported general language is requested", (callback) ->
+  it "should not use a country specific language when an unsupported general language is requested", (callback) ->
     http.get port: 8001, headers: "Accept-Language": "da", (res) ->
       assert.equal(
         res.headers["content-language"]
-        "da-DK"
+        defaultLocale
       )
       callback()
 
-  it "should fallback to a country specific language even when there's a lower quality exact match", (callback) ->
+  it "should not fallback to a country specific language when there's an exact match", (callback) ->
     http.get port: 8001, headers: "Accept-Language": "ja;q=.8, da", (res) ->
       assert.equal(
         res.headers["content-language"]
-        "da-DK"
+        "ja"
       )
       assert.equal(false, !res.headers["defaulted"])
       callback()


### PR DESCRIPTION
If we have a language that is good for all locales, we can name that
language by just language (e.g. 'pt'). What we should NOT do is match
'pt-PT' to 'pt-BR' in the absence of 'pt'.

This is apparently desired behavior in the current jed/locale, so we'll
fork.
